### PR TITLE
Fix: mcs_map doesn't call block during iteration over every element of array

### DIFF
--- a/Classes/NSArray+MCSCollectionUtility.m
+++ b/Classes/NSArray+MCSCollectionUtility.m
@@ -156,7 +156,7 @@
   
   [self mcs_each:^(id object) {
     
-    [resultArray addObject:object];
+    [resultArray addObject:block(object)];
     
   }];
   


### PR DESCRIPTION
Hi! I think there is a bug in `mcs_map`. I've just noticed that method's argument `block` is never called.
